### PR TITLE
ISSUE-2: Warn user if New Game or Quit will terminate a game in progress

### DIFF
--- a/WordleGS.xcodeproj/project.pbxproj
+++ b/WordleGS.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 			children = (
 				3678008327A100E7002A9ACC /* main.h */,
 				3678008127A100E7002A9ACC /* main.c */,
+				3678008427A100E7002A9ACC /* main.rez */,
 				36B5FF0627A3A06D0097B2BD /* wgs_about_dialog.h */,
 				36B5FF0327A3A06D0097B2BD /* wgs_about_dialog.c */,
 				36B5FF0727A3A06D0097B2BD /* wgs_app_window.h */,
@@ -141,7 +142,6 @@
 				36B5FF0F27A3A06D0097B2BD /* wgs_render_system.h */,
 				36B5FF0E27A3A06D0097B2BD /* wgs_render_system.c */,
 				36B5FF0027A3A06D0097B2BD /* data */,
-				3678008427A100E7002A9ACC /* main.rez */,
 				3678008627A100E7002A9ACC /* Makefile */,
 				3678008827A100E7002A9ACC /* make */,
 				367800A127A100E7002A9ACC /* Supporting Files */,

--- a/WordleGS/main.c
+++ b/WordleGS/main.c
@@ -37,6 +37,7 @@
 
 #include "wgs_app_window.h"
 #include "wgs_game_entities.h"
+#include "wgs_game_model.h"
 #include "wgs_render_system.h"
 #include "wgs_about_dialog.h"
 #include "wgs_dictionary.h"
@@ -46,12 +47,26 @@ EventRecord my_event;
 int menu_num, menu_item_num;
 
 
+void HandleQuitGame(void) {
+  Word alert_result;
+
+  if (IsGameInProgress()) {
+    alert_result = AlertWindow(awResource, NULL, rez_alert_VerifyQuitGame);
+    if (alert_result == rez_alert_VerifyNewGame_Cancel) {
+      return;
+    }
+  }
+
+  done = TRUE;
+}
+
+
 void HandleMenu (void) {
   int i;
   
   switch (menu_item_num) {
     case file_Quit:
-      done = TRUE;
+      HandleQuitGame();
       break;
       
     case 255:

--- a/WordleGS/main.h
+++ b/WordleGS/main.h
@@ -25,6 +25,19 @@
 #ifndef _____PROJECTNAMEASIDENTIFIER________FILEBASENAMEASIDENTIFIER_____
 #define _____PROJECTNAMEASIDENTIFIER________FILEBASENAMEASIDENTIFIER_____
 
+/* *****************************************************************************
+ * Alerts
+ * *****************************************************************************/
+
+#define rez_alert_UnknownWord                   1001
+
+#define rez_alert_VerifyNewGame                 1002
+#define rez_alert_VerifyNewGame_Cancel             1
+
+#define rez_alert_VerifyQuitGame                1003
+#define rez_alert_VerifyNewGame_Cancel             1
+
+
 #define file_Quit       256
 
 #endif /* defined(_____PROJECTNAMEASIDENTIFIER________FILEBASENAMEASIDENTIFIER_____) */

--- a/WordleGS/main.rez
+++ b/WordleGS/main.rez
@@ -23,13 +23,37 @@
  */
 
 #include "types.rez"
+#include "main.h"
 
-resource rAlertString (1) {
-  "43/"
-  "I don't know the word: *0\n"
+
+/* *****************************************************************************
+ * Alerts
+ * *****************************************************************************/
+
+resource rAlertString (rez_alert_UnknownWord) {
+  "33/"
+  "I don't know the word:\n"
+  "*0\n"
   "/^#0"
   $"00";
 };
+
+resource rAlertString (rez_alert_VerifyNewGame) {
+  "34/"
+  "New Game will terminate the current game.\n"
+  "/New Game"
+  "/^#1"
+  $"00";
+};
+
+resource rAlertString (rez_alert_VerifyQuitGame) {
+  "34/"
+  "Quit will terminate the current game.\n"
+  "/Quit"
+  "/^#1"
+  $"00";
+};
+
 
 resource rWindParam1 (1001) {
   $DDA5,                      /* wFrameBits */

--- a/WordleGS/wgs_app_window.c
+++ b/WordleGS/wgs_app_window.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <time.h>
 
+#include "main.h"
 #include "wgs_app_window.h"
 #include "wgs_dictionary.h"
 #include "wgs_game_entities.h"
@@ -67,6 +68,15 @@ void InvalidateWindow(void) {
 
 void HandleNewGame(void) {
   char word[16];
+  Word alert_result;
+
+  if (IsGameInProgress()) {
+    alert_result = AlertWindow(awResource, NULL, rez_alert_VerifyNewGame);
+    if (alert_result == rez_alert_VerifyNewGame_Cancel) {
+      return;
+    }
+  }
+
   announce_status = NoAnnouncement;
 
   ResetLetterGuessEntities();
@@ -95,7 +105,7 @@ void HandleKeyPress (EventRecord event)
     
     if (status == InvalidWord) {
       char *guess_word = GetGuessWord();
-      AlertWindow(awCString+awResource, (Pointer) &guess_word, 1);
+      AlertWindow(awCString+awResource, (Pointer) &guess_word, rez_alert_UnknownWord);
       manual_update_needed = false;
     }
   }

--- a/WordleGS/wgs_game_model.c
+++ b/WordleGS/wgs_game_model.c
@@ -195,6 +195,11 @@ wgs_game_state GetGameState(void) {
 }
 
 
+BOOLEAN IsGameInProgress(void) {
+  return game_state == InProgress && (current_guess_row > 0 || current_guess_col > 0);
+}
+
+
 int GetGuessRow(void) {
   return current_guess_row;
 }

--- a/WordleGS/wgs_game_model.h
+++ b/WordleGS/wgs_game_model.h
@@ -25,6 +25,9 @@
 #ifndef _GUARD_PROJECTWordleGS_FILEwgs_game_model_
 #define _GUARD_PROJECTWordleGS_FILEwgs_game_model_
 
+#include <misctool.h>
+
+
 typedef enum { Unknown, Correct, WrongPlace, UnusedLetter } wgs_square_state;
 
 typedef enum { InProgress, Won, Lost } wgs_game_state;
@@ -44,6 +47,7 @@ wgs_square_state GetGuessSquareStatus(int row, int col);
 wgs_square_state GetLetterStatus(char c);
 
 wgs_game_state GetGameState(void);
+BOOLEAN IsGameInProgress(void);
 int GetGuessRow(void);
 int GetGuessCol(void);
 char *GetSecretWord(void);


### PR DESCRIPTION
Warn the user if they select _New Game_ or _Quit_ when a game is actively in progress. Default button in each case will be to cancel and return to the game in progress.