### PR TITLE
REFACTOR: Fix Xcode classification of source files

### DIFF
--- a/WordleGS.xcodeproj/project.pbxproj
+++ b/WordleGS.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3630F8D227A5B2F60018042C /* wgs_game_entities.c in Sources */ = {isa = PBXBuildFile; fileRef = 3630F8CC27A5B2F60018042C /* wgs_game_entities.c */; };
+		3630F8D327A5B2F60018042C /* wgs_app_window.c in Sources */ = {isa = PBXBuildFile; fileRef = 3630F8CD27A5B2F60018042C /* wgs_app_window.c */; };
+		3630F8D427A5B2F60018042C /* wgs_game_model.c in Sources */ = {isa = PBXBuildFile; fileRef = 3630F8CE27A5B2F60018042C /* wgs_game_model.c */; };
+		3630F8D527A5B2F60018042C /* wgs_game_over_dialog.c in Sources */ = {isa = PBXBuildFile; fileRef = 3630F8CF27A5B2F60018042C /* wgs_game_over_dialog.c */; };
+		3630F8D627A5B2F60018042C /* wgs_dictionary.c in Sources */ = {isa = PBXBuildFile; fileRef = 3630F8D027A5B2F60018042C /* wgs_dictionary.c */; };
+		3630F8D727A5B2F60018042C /* wgs_render_system.c in Sources */ = {isa = PBXBuildFile; fileRef = 3630F8D127A5B2F60018042C /* wgs_render_system.c */; };
 		3678008227A100E7002A9ACC /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 3678008127A100E7002A9ACC /* main.c */; };
 		3678008527A100E7002A9ACC /* main.rez in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3678008427A100E7002A9ACC /* main.rez */; };
 		3678008727A100E7002A9ACC /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = 3678008627A100E7002A9ACC /* Makefile */; };
@@ -52,6 +58,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3630F8C627A5B2EA0018042C /* wgs_render_system.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wgs_render_system.h; sourceTree = "<group>"; };
+		3630F8C727A5B2EB0018042C /* wgs_game_over_dialog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wgs_game_over_dialog.h; sourceTree = "<group>"; };
+		3630F8C827A5B2EB0018042C /* wgs_dictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wgs_dictionary.h; sourceTree = "<group>"; };
+		3630F8C927A5B2EB0018042C /* wgs_game_model.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wgs_game_model.h; sourceTree = "<group>"; };
+		3630F8CA27A5B2EB0018042C /* wgs_app_window.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wgs_app_window.h; sourceTree = "<group>"; };
+		3630F8CB27A5B2EB0018042C /* wgs_game_entities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wgs_game_entities.h; sourceTree = "<group>"; };
+		3630F8CC27A5B2F60018042C /* wgs_game_entities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_game_entities.c; sourceTree = "<group>"; };
+		3630F8CD27A5B2F60018042C /* wgs_app_window.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_app_window.c; sourceTree = "<group>"; };
+		3630F8CE27A5B2F60018042C /* wgs_game_model.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_game_model.c; sourceTree = "<group>"; };
+		3630F8CF27A5B2F60018042C /* wgs_game_over_dialog.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_game_over_dialog.c; sourceTree = "<group>"; };
+		3630F8D027A5B2F60018042C /* wgs_dictionary.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_dictionary.c; sourceTree = "<group>"; };
+		3630F8D127A5B2F60018042C /* wgs_render_system.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_render_system.c; sourceTree = "<group>"; };
 		3678007527A100E7002A9ACC /* WordleGS */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WordleGS; sourceTree = BUILT_PRODUCTS_DIR; };
 		3678007827A100E7002A9ACC /* WordleGS.2mg */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WordleGS.2mg; sourceTree = BUILT_PRODUCTS_DIR; };
 		3678007A27A100E7002A9ACC /* WordleGS.shk */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WordleGS.shk; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -73,20 +91,8 @@
 		3678009D27A100E7002A9ACC /* tar */ = {isa = PBXFileReference; lastKnownFileType = file; path = tar; sourceTree = "<group>"; };
 		3678009F27A100E7002A9ACC /* tail.mk */ = {isa = PBXFileReference; lastKnownFileType = text; path = tail.mk; sourceTree = "<group>"; };
 		367800A227A100E7002A9ACC /* WordleGS.xcscheme */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = WordleGS.xcscheme; path = ../../WordleGS.xcodeproj/xcshareddata/xcschemes/WordleGS.xcscheme; sourceTree = "<group>"; };
-		36B5FEFE27A3A06D0097B2BD /* wgs_game_model.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_game_model.c; sourceTree = "<group>"; };
-		36B5FEFF27A3A06D0097B2BD /* wgs_dictionary.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_dictionary.c; sourceTree = "<group>"; };
 		36B5FF0127A3A06D0097B2BD /* dictionary.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = dictionary.txt; sourceTree = "<group>"; };
 		36B5FF0227A3A06D0097B2BD /* secrets.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = secrets.txt; sourceTree = "<group>"; };
-		36B5FF0427A3A06D0097B2BD /* wgs_game_entities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wgs_game_entities.h; sourceTree = "<group>"; };
-		36B5FF0727A3A06D0097B2BD /* wgs_app_window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wgs_app_window.h; sourceTree = "<group>"; };
-		36B5FF0827A3A06D0097B2BD /* wgs_game_over_dialog.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_game_over_dialog.c; sourceTree = "<group>"; };
-		36B5FF0A27A3A06D0097B2BD /* wgs_dictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wgs_dictionary.h; sourceTree = "<group>"; };
-		36B5FF0B27A3A06D0097B2BD /* wgs_game_entities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_game_entities.c; sourceTree = "<group>"; };
-		36B5FF0C27A3A06D0097B2BD /* wgs_game_model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wgs_game_model.h; sourceTree = "<group>"; };
-		36B5FF0D27A3A06D0097B2BD /* wgs_game_over_dialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wgs_game_over_dialog.h; sourceTree = "<group>"; };
-		36B5FF0E27A3A06D0097B2BD /* wgs_render_system.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_render_system.c; sourceTree = "<group>"; };
-		36B5FF0F27A3A06D0097B2BD /* wgs_render_system.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wgs_render_system.h; sourceTree = "<group>"; };
-		36B5FF1027A3A06D0097B2BD /* wgs_app_window.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wgs_app_window.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,18 +131,18 @@
 				3678008327A100E7002A9ACC /* main.h */,
 				3678008127A100E7002A9ACC /* main.c */,
 				3678008427A100E7002A9ACC /* main.rez */,
-				36B5FF0727A3A06D0097B2BD /* wgs_app_window.h */,
-				36B5FF1027A3A06D0097B2BD /* wgs_app_window.c */,
-				36B5FF0A27A3A06D0097B2BD /* wgs_dictionary.h */,
-				36B5FEFF27A3A06D0097B2BD /* wgs_dictionary.c */,
-				36B5FF0427A3A06D0097B2BD /* wgs_game_entities.h */,
-				36B5FF0B27A3A06D0097B2BD /* wgs_game_entities.c */,
-				36B5FF0C27A3A06D0097B2BD /* wgs_game_model.h */,
-				36B5FEFE27A3A06D0097B2BD /* wgs_game_model.c */,
-				36B5FF0D27A3A06D0097B2BD /* wgs_game_over_dialog.h */,
-				36B5FF0827A3A06D0097B2BD /* wgs_game_over_dialog.c */,
-				36B5FF0F27A3A06D0097B2BD /* wgs_render_system.h */,
-				36B5FF0E27A3A06D0097B2BD /* wgs_render_system.c */,
+				3630F8CA27A5B2EB0018042C /* wgs_app_window.h */,
+				3630F8CD27A5B2F60018042C /* wgs_app_window.c */,
+				3630F8C827A5B2EB0018042C /* wgs_dictionary.h */,
+				3630F8D027A5B2F60018042C /* wgs_dictionary.c */,
+				3630F8CB27A5B2EB0018042C /* wgs_game_entities.h */,
+				3630F8CC27A5B2F60018042C /* wgs_game_entities.c */,
+				3630F8C927A5B2EB0018042C /* wgs_game_model.h */,
+				3630F8CE27A5B2F60018042C /* wgs_game_model.c */,
+				3630F8C727A5B2EB0018042C /* wgs_game_over_dialog.h */,
+				3630F8CF27A5B2F60018042C /* wgs_game_over_dialog.c */,
+				3630F8C627A5B2EA0018042C /* wgs_render_system.h */,
+				3630F8D127A5B2F60018042C /* wgs_render_system.c */,
 				36B5FF0027A3A06D0097B2BD /* data */,
 				3678008627A100E7002A9ACC /* Makefile */,
 				3678008827A100E7002A9ACC /* make */,
@@ -311,7 +317,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3630F8D727A5B2F60018042C /* wgs_render_system.c in Sources */,
+				3630F8D427A5B2F60018042C /* wgs_game_model.c in Sources */,
+				3630F8D527A5B2F60018042C /* wgs_game_over_dialog.c in Sources */,
+				3630F8D227A5B2F60018042C /* wgs_game_entities.c in Sources */,
+				3630F8D327A5B2F60018042C /* wgs_app_window.c in Sources */,
 				3678008727A100E7002A9ACC /* Makefile in Sources */,
+				3630F8D627A5B2F60018042C /* wgs_dictionary.c in Sources */,
 				3678008227A100E7002A9ACC /* main.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordleGS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/WordleGS.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,24 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:/Users/danmalec/Documents/IIGS/Wordle.GS/WordleGS/wgs_app_window.h">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/danmalec/Documents/IIGS/Wordle.GS/WordleGS/wgs_dictionary.h">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/danmalec/Documents/IIGS/Wordle.GS/WordleGS/wgs_game_entities.h">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/danmalec/Documents/IIGS/Wordle.GS/WordleGS/wgs_game_model.h">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/danmalec/Documents/IIGS/Wordle.GS/WordleGS/wgs_game_over_dialog.h">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/danmalec/Documents/IIGS/Wordle.GS/WordleGS/wgs_render_system.h">
+   </FileRef>
+   <FileRef
       location = "self:">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
Fix Xcode classification of source files so syntax highlighting, etc. work