### PR TITLE
UX: Add Next Word menu item

### DIFF
--- a/WordleGS/main.c
+++ b/WordleGS/main.c
@@ -45,6 +45,12 @@ BOOLEAN done;
 EventRecord my_event;
 int menu_num, menu_item_num;
 
+/* Prototypes */
+
+void HandleNextRound(void);
+
+
+/* Implementation */
 
 void HandleAboutDialog(void) {
   AlertWindow(awResource, NULL, rez_alert_About);
@@ -75,6 +81,17 @@ void HandleNewGame(void) {
   
   GameEngine_NewGame(code_c_string);
   AppWindow_NextRound();
+}
+
+void HandleNextWord(void) {  
+  if (GameEngine_IsGameInProgress()) {
+    Word alert_result = AlertWindow(awResource, NULL, rez_alert_VerifyNextWord);
+    if (alert_result == rez_alert_VerifyNextWord_Cancel) {
+      return;
+    }
+  }
+
+  HandleNextRound();
 }
 
 void HandleNextRound(void) {
@@ -114,6 +131,10 @@ void HandleMenu (void) {
 
     case rez_menuitem_HelpId:
       HelpDialog_Show();
+      break;
+
+    case rez_menuitem_NextWordId:
+      HandleNextWord();
       break;
       
   }

--- a/WordleGS/main.h
+++ b/WordleGS/main.h
@@ -94,6 +94,16 @@
 #define rez_menuitem_ClearId                     254
 #define rez_menuitem_ClearTitle                  254
 
+/* Game Menu */
+
+#define rez_menu_Game                              4
+#define rez_menu_GameId                            4
+#define rez_menu_GameTitle                         4
+
+#define rez_menuitem_NextWord                    401
+#define rez_menuitem_NextWordId                  401
+#define rez_menuitem_NextWordTitle               401
+
 
 /* *****************************************************************************
  * Alerts
@@ -106,7 +116,10 @@
 #define rez_alert_VerifyNewGame                 1003
 #define rez_alert_VerifyNewGame_Cancel             1
 
-#define rez_alert_VerifyQuitGame                1004
+#define rez_alert_VerifyNextWord                1004
+#define rez_alert_VerifyNextWord_Cancel            1
+
+#define rez_alert_VerifyQuitGame                1005
 #define rez_alert_VerifyNewGame_Cancel             1
 
 /* *****************************************************************************

--- a/WordleGS/main.rez
+++ b/WordleGS/main.rez
@@ -34,7 +34,8 @@ resource rMenuBar (rez_menubar_Main) {
   {
     rez_menu_Apple,
     rez_menu_File,
-    rez_menu_Edit
+    rez_menu_Edit,
+    rez_menu_Game
   };
 };
 
@@ -197,6 +198,30 @@ resource rMenuItem (rez_menuitem_Clear) {
 
 resource rPString (rez_menuitem_ClearTitle, noCrossBank) {"Clear"};
 
+/* Game Menu */
+
+resource rMenu (rez_menu_Game) {
+  rez_menu_GameId,
+  refIsResource*menuTitleRefShift
+  + refIsResource*itemRefShift
+  + fAllowCache,
+  rez_menu_GameTitle,
+  {
+    rez_menuitem_NextWord
+  };
+};
+
+resource rPString (rez_menu_GameTitle, noCrossBank) {" Game "};
+
+resource rMenuItem (rez_menuitem_NextWord) {
+  rez_menuitem_NextWordId,
+  ">",".",
+  0,
+  refIsResource*itemTitleRefShift,
+  rez_menuitem_NextWordTitle
+};
+
+resource rPString (rez_menuitem_NextWordTitle, noCrossBank) {"Next Word"};
 
 /* *****************************************************************************
  * Alerts
@@ -241,6 +266,18 @@ resource rAlertString (rez_alert_VerifyNewGame) {
   "New Game will terminate the current game.\n"     /* text */
   "/"                                               /* divider */
   "New Game"                                        /* button */
+  "/"                                               /* divider */
+  "^#1"                                             /* button */
+  $"00";                                            /* terminator */
+};
+
+resource rAlertString (rez_alert_VerifyNextWord) {
+  "3"                                               /* size */
+  "4"                                               /* icon */
+  "/"                                               /* divider */
+  "Next Word will terminate the current word.\n"    /* text */
+  "/"                                               /* divider */
+  "Next Word"                                       /* button */
   "/"                                               /* divider */
   "^#1"                                             /* button */
   $"00";                                            /* terminator */
@@ -549,7 +586,7 @@ resource rControlTemplate (rez_window_NewGame_GameCode) {
     $0000,                                          /* flags */
     $7000,                                          /* more flags */
     0,                                              /* refcon */
-    6,                                              /* max size */
+    5,                                              /* max size */
     0                                               /* text Ref */
   }};
 };


### PR DESCRIPTION
Add Next Word menu item so player can close the stats box after playing a word and still move forward in the word sequence.